### PR TITLE
fix a bug may throw exception when draw danmuku

### DIFF
--- a/DanmakuFlameMaster/src/main/java/master/flame/danmaku/danmaku/model/android/AndroidDisplayer.java
+++ b/DanmakuFlameMaster/src/main/java/master/flame/danmaku/danmaku/model/android/AndroidDisplayer.java
@@ -197,7 +197,7 @@ public class AndroidDisplayer extends AbsDisplayer<Canvas> {
             boolean cacheDrawn = false;
             if (danmaku.hasDrawingCache()) {
                 DrawingCacheHolder holder = ((DrawingCache) danmaku.cache).get();
-                if (holder != null && holder.bitmap != null) {
+                if (holder != null && holder.bitmap != null && !holder.bitmap.isRecycled()) {
                     canvas.drawBitmap(holder.bitmap, left, top, alphaPaint);                    
                     cacheDrawn = true;
                 }


### PR DESCRIPTION
报错信息如下
java.lang.RuntimeException: Canvas: trying to use a recycled bitmap android.graphics.Bitmap@4290fee
at android.graphics.Canvas.throwIfRecycled(Canvas.java:1026)
at android.graphics.Canvas.drawBitmap(Canvas.java:1065)
at master.flame.danmaku.danmaku.model.android.AndroidDisplayer.draw(Unknown Source)
at master.flame.danmaku.danmaku.model.BaseDanmaku.draw(Unknown Source)
at master.flame.danmaku.danmaku.renderer.android.DanmakuRenderer.draw(Unknown Source)
at master.flame.danmaku.controller.DrawTask.drawDanmakus(Unknown Source)
at master.flame.danmaku.controller.DrawTask.draw(Unknown Source)
at master.flame.danmaku.controller.CacheManagingDrawTask.draw(Unknown Source)
at master.flame.danmaku.controller.DrawHandler.draw(Unknown Source)
at master.flame.danmaku.ui.widget.DanmakuSurfaceView.drawDanmakus(Unknown Source)
at master.flame.danmaku.controller.DrawHandler.handleMessage(Unknown Source)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:153)
at android.os.HandlerThread.run(HandlerThread.java:60)

AndroidDisplayer 200行
if (holder != null && holder.bitmap != null )->
if (holder != null && holder.bitmap != null && !holder.bitmap.isRecycled())
