### PR TITLE
修复多行文本绘制时的textheight计算错误。这里的danmaku.paintHeight 已经包含了2* padding了，所以计算tex...

### DIFF
--- a/DanmakuFlameMaster/src/main/java/master/flame/danmaku/danmaku/model/android/AndroidDisplayer.java
+++ b/DanmakuFlameMaster/src/main/java/master/flame/danmaku/danmaku/model/android/AndroidDisplayer.java
@@ -276,7 +276,7 @@ public class AndroidDisplayer extends AbsDisplayer<Canvas> {
                 applyPaintConfig(danmaku, paint, false);
                 canvas.drawText(lines[0], left, top - paint.ascent(), paint);
             } else {
-                float textHeight = danmaku.paintHeight / lines.length;
+                float textHeight = (danmaku.paintHeight - 2 * danmaku.padding) / lines.length;
                 for (int t = 0; t < lines.length; t++) {
                     if (lines[t] == null || lines[t].length() == 0) {
                         continue;


### PR DESCRIPTION
修复多行文本绘制时的textheight计算错误。这里的danmaku.paintHeight 已经包含了2\* padding了，所以计算textheight时应该去除 2*padding 这段距离，否则多行文本的情况下最末一行文字会被截断，显示不全。
