### PR TITLE
bugfix: compare方法最后对象使用错误

### DIFF
--- a/DanmakuFlameMaster/src/main/java/master/flame/danmaku/danmaku/util/DanmakuUtils.java
+++ b/DanmakuFlameMaster/src/main/java/master/flame/danmaku/danmaku/util/DanmakuUtils.java
@@ -149,7 +149,7 @@ public class DanmakuUtils {
         if (r != 0)
             return r < 0 ? -1 : 1;
 
-        r = obj1.hashCode() - obj1.hashCode();
+        r = obj1.hashCode() - obj2.hashCode();
         return r;
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3285051/75427349-4ca8b700-5981-11ea-820f-a740931c869f.png)
对象使用错误，导致最后hashCode相减永远是0